### PR TITLE
Fix for Go v1

### DIFF
--- a/serial/open_darwin.go
+++ b/serial/open_darwin.go
@@ -234,7 +234,7 @@ func openInternal(options OpenOptions) (io.ReadWriteCloser, error) {
 			uintptr(0))
 
 	if errno != 0 {
-		return nil, os.NewSyscallError("SYS_IOCTL", errno)
+		return nil, os.NewSyscallError("SYS_FCNTL", errno)
 	}
 
 	if r1 != 0 {


### PR DESCRIPTION
This fixes a few build errors where the `syscall` interfaces appear to have changed since this package was written. Otherwise, everything seems to work fine.
