### PR TITLE
Added support for Windows

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@ This is a package that allows you to read from and write to serial ports in Go.
 OS support
 ==========
 
-Currently this package works only on OS X and Linux. It could probably be ported
+Currently this package works only on OS X, Linux and Windows. It could probably be ported
 to other Unix-like platforms simply by updating a few constants; get in touch if
 you are interested in helping and have hardware to test with. Windows would
 likely be a lot more work.

--- a/serial/open_windows.go
+++ b/serial/open_windows.go
@@ -16,11 +16,8 @@ package serial
 
 import (
 	"fmt"
-	//"log"
-	//"github.com/hotei/bits"
 	"io"
 	"os"
-	//"strconv"
 	"sync"
 	"syscall"
 	"unsafe"
@@ -44,39 +41,6 @@ type structDCB struct {
 	wReserved1                                     uint16
 }
 
-/*
-type _DCB struct {
-  DWORD DCBlength
-  DWORD BaudRate
-  DWORD fBinary  :1
-  DWORD fParity  :1
-  DWORD fOutxCtsFlow  :1
-  DWORD fOutxDsrFlow  :1
-  DWORD fDtrControl  :2
-  DWORD fDsrSensitivity  :1
-  DWORD fTXContinueOnXoff  :1
-  DWORD fOutX  :1
-  DWORD fInX  :1
-  DWORD fErrorChar  :1
-  DWORD fNull  :1
-  DWORD fRtsControl  :2 /* 13 and 14th bit, so [12:13]
-  DWORD fAbortOnError  :1
-  DWORD fDummy2  :17
-  WORD  wReserved
-  WORD  XonLim
-  WORD  XoffLim
-  BYTE  ByteSize
-  BYTE  Parity
-  BYTE  StopBits
-  char  XonChar
-  char  XoffChar
-  char  ErrorChar
-  char  EofChar
-  char  EvtChar
-  WORD  wReserved1
-}
-*/
-
 type structTimeouts struct {
 	ReadIntervalTimeout         uint32
 	ReadTotalTimeoutMultiplier  uint32
@@ -84,6 +48,7 @@ type structTimeouts struct {
 	WriteTotalTimeoutMultiplier uint32
 	WriteTotalTimeoutConstant   uint32
 }
+
 func openInternal(options OpenOptions) (io.ReadWriteCloser, error) {
 	if len(options.PortName) > 0 && options.PortName[0] != '\\' {
 		options.PortName = "\\\\.\\" + options.PortName
@@ -214,9 +179,6 @@ func setCommState(h syscall.Handle, options OpenOptions) error {
 
 	params.flags[0] = 0x01  // fBinary
 	params.flags[0] |= 0x10 // Assert DSR
-	//params.flags[1] = 0x10  // RTS is on
-	//log.Println("Byte val of commstat flags[0]:", strconv.FormatInt(int64(params.flags[0]), 2))
-	//log.Println("Byte val of commstat flags[1]:", strconv.FormatInt(int64(params.flags[1]), 2))
 
 	if options.ParityMode != PARITY_NONE {
 		params.flags[0] |= 0x03 // fParity


### PR DESCRIPTION
This adds windows support. It's mostly just copy/paste from [tarm/goserial](https://github.com/tarm/goserial).
I've tested it on Windows 7 and 8 with amd64 and Windows XP with i386.

Now we can finally have a good cross platform serial library without the need for Cgo.