### PR TITLE
Fixed OSX virtual serial port support

### DIFF
--- a/serial/serial.go
+++ b/serial/serial.go
@@ -31,6 +31,40 @@ const (
 	PARITY_EVEN ParityMode = 2
 )
 
+var (
+	// The list of standard baud-rates.
+	StandardBaudRates = map[uint]bool{
+		50:     true,
+		75:     true,
+		110:    true,
+		134:    true,
+		150:    true,
+		200:    true,
+		300:    true,
+		600:    true,
+		1200:   true,
+		1800:   true,
+		2400:   true,
+		4800:   true,
+		7200:   true,
+		9600:   true,
+		14400:  true,
+		19200:  true,
+		28800:  true,
+		38400:  true,
+		57600:  true,
+		76800:  true,
+		115200: true,
+		230400: true,
+	}
+)
+
+// IsStandardBaudRate checks whether the specified baud-rate is standard.
+//
+// Some operating systems may support non-standard baud-rates (OSX) via
+// additional IOCTL.
+func IsStandardBaudRate(baudRate uint) bool { return StandardBaudRates[baudRate] }
+
 // OpenOptions is the struct containing all of the options necessary for
 // opening a serial port.
 type OpenOptions struct {

--- a/serial/serial_test.go
+++ b/serial/serial_test.go
@@ -1,0 +1,50 @@
+package serial
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsStandardBaudRate(t *testing.T) {
+	testCases := []struct {
+		BaudRate   uint
+		IsStandard bool
+	}{
+		{50, true},
+		{75, true},
+		{110, true},
+		{134, true},
+		{150, true},
+		{200, true},
+		{300, true},
+		{600, true},
+		{1200, true},
+		{1800, true},
+		{2400, true},
+		{4800, true},
+		{7200, true},
+		{9600, true},
+		{14400, true},
+		{19200, true},
+		{28800, true},
+		{38400, true},
+		{57600, true},
+		{76800, true},
+		{115200, true},
+		{230400, true},
+		{0, false},
+		{123, false},
+		{14401, false},
+	}
+
+	for _, testCase := range testCases {
+		testName := fmt.Sprintf("%d", testCase.BaudRate)
+		t.Run(testName, func(t *testing.T) {
+			result := IsStandardBaudRate(testCase.BaudRate)
+
+			if result != testCase.IsStandard {
+				t.Errorf("expected result to be %t, but got %t", testCase.IsStandard, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull-request follows the discussion on #10 and suggests an implementation that is fully backward-compatible.

The initial problem, as stated in the discussion, is that the code was recently modified to allow for non-standard baud-rates on OSX (see #7). While those changes indeed do what they are supposed to, they rely on a non-standard/non-portable IOCTL that only works on real serial devices, but fails on everything else.

Since this non-standard IOCTL is only ever needed when we want to set a non-standard baud-rate, the suggested changes here first test if the desired baud-rate is a standard one (that list is static anyway) and then decide on a strategy. If the baud-rate is standard, we use the standard IOCTL. If it isn't, we use the non-standard IOCTL as implemented in #7.

I also added unit-tests for the new introduced function, even though its implementation is particularly trivial.

Let me know what you think @jacobsa !