### PR TITLE
Make port's file descriptor available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/jacobsa/go-serial
+
+go 1.17
+
+require golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7 h1:c20P3CcPbopVp2f7099WLOqSNKURf30Z0uq66HpijZY=
+golang.org/x/sys v0.0.0-20210923061019-b8560ed6a9b7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/serial/open_darwin.go
+++ b/serial/open_darwin.go
@@ -277,3 +277,7 @@ func (p *port) Flush(in, out bool) error {
 	}
 	return nil
 }
+
+func (p *port) PortName() string {
+	return p.Name()
+}

--- a/serial/open_darwin.go
+++ b/serial/open_darwin.go
@@ -27,11 +27,10 @@ package serial
 
 import (
 	"errors"
-	"io"
+	"os"
+	"syscall"
+	"unsafe"
 )
-import "os"
-import "syscall"
-import "unsafe"
 
 // termios types
 type cc_t byte
@@ -196,7 +195,7 @@ func convertOptions(options OpenOptions) (*termios, error) {
 	return &result, nil
 }
 
-func openInternal(options OpenOptions) (io.ReadWriteCloser, error) {
+func openInternal(options OpenOptions) (*os.File, error) {
 	// Open the serial port in non-blocking mode, since otherwise the OS will
 	// wait for the CARRIER line to be asserted.
 	file, err :=

--- a/serial/open_freebsd.go
+++ b/serial/open_freebsd.go
@@ -16,6 +16,6 @@ package serial
 
 import "io"
 
-func openInternal(options OpenOptions) (io.ReadWriteCloser, error) {
+func openInternal(options OpenOptions) (Port, error) {
 	return nil, "Not implemented on this OS."
 }

--- a/serial/open_linux.go
+++ b/serial/open_linux.go
@@ -2,6 +2,7 @@ package serial
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"syscall"
 	"unsafe"
@@ -137,7 +138,9 @@ func makeTermios2(options OpenOptions) (*termios2, error) {
 	return t2, nil
 }
 
-func openInternal(options OpenOptions) (*os.File, error) {
+type port struct{ *os.File }
+
+func openInternal(options OpenOptions) (*port, error) {
 
 	file, openErr :=
 		os.OpenFile(
@@ -204,5 +207,23 @@ func openInternal(options OpenOptions) (*os.File, error) {
 		}
 	}
 
-	return file, nil
+	return &port{file}, nil
+}
+
+func (p *port) Flush(in, out bool) error {
+	var queueSel int
+	if in && out {
+		queueSel = unix.TCIOFLUSH
+	} else if in {
+		queueSel = unix.TCIFLUSH
+	} else if out {
+		queueSel = unix.TCOFLUSH
+	} else {
+		return nil
+	}
+	// TCFLSH = 0x540B aka tcflush()
+	if err := unix.IoctlSetInt(int(p.Fd()), 0x540B, queueSel); err != nil {
+		return fmt.Errorf("tcflush failed: %w", err)
+	}
+	return nil
 }

--- a/serial/open_linux.go
+++ b/serial/open_linux.go
@@ -2,7 +2,6 @@ package serial
 
 import (
 	"errors"
-	"io"
 	"os"
 	"syscall"
 	"unsafe"
@@ -138,7 +137,7 @@ func makeTermios2(options OpenOptions) (*termios2, error) {
 	return t2, nil
 }
 
-func openInternal(options OpenOptions) (io.ReadWriteCloser, error) {
+func openInternal(options OpenOptions) (*os.File, error) {
 
 	file, openErr :=
 		os.OpenFile(

--- a/serial/open_linux.go
+++ b/serial/open_linux.go
@@ -227,3 +227,7 @@ func (p *port) Flush(in, out bool) error {
 	}
 	return nil
 }
+
+func (p *port) PortName() string {
+	return p.Name()
+}

--- a/serial/open_windows.go
+++ b/serial/open_windows.go
@@ -16,7 +16,6 @@ package serial
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"sync"
 	"syscall"
@@ -49,7 +48,7 @@ type structTimeouts struct {
 	WriteTotalTimeoutConstant   uint32
 }
 
-func openInternal(options OpenOptions) (io.ReadWriteCloser, error) {
+func openInternal(options OpenOptions) (*serialPort, error) {
 	if len(options.PortName) > 0 && options.PortName[0] != '\\' {
 		options.PortName = "\\\\.\\" + options.PortName
 	}
@@ -137,6 +136,10 @@ func (p *serialPort) Read(buf []byte) (int, error) {
 		return int(done), err
 	}
 	return getOverlappedResult(p.fd, p.ro)
+}
+
+func (p *serialPort) Fd() uintptr {
+	return p.f.Fd()
 }
 
 var (

--- a/serial/open_windows.go
+++ b/serial/open_windows.go
@@ -345,3 +345,7 @@ func getOverlappedResult(h syscall.Handle, overlapped *syscall.Overlapped) (int,
 
 	return n, nil
 }
+
+func (p *serialPort) PortName() string {
+	return p.f.Name()
+}

--- a/serial/serial.go
+++ b/serial/serial.go
@@ -164,6 +164,7 @@ type Port interface {
 	io.ReadWriteCloser
 	Fd() uintptr
 	Flush(in, out bool) error
+	PortName() string
 }
 
 // Open creates a Port based on the supplied options struct.

--- a/serial/serial.go
+++ b/serial/serial.go
@@ -159,8 +159,14 @@ type OpenOptions struct {
 	Rs485DelayRtsAfterSend int
 }
 
-// Open creates an io.ReadWriteCloser based on the supplied options struct.
-func Open(options OpenOptions) (io.ReadWriteCloser, error) {
+// Port defines the serial port.
+type Port interface {
+	io.ReadWriteCloser
+	Fd() uintptr
+}
+
+// Open creates a Port based on the supplied options struct.
+func Open(options OpenOptions) (Port, error) {
 	// Redirect to the OS-specific function.
 	return openInternal(options)
 }

--- a/serial/serial.go
+++ b/serial/serial.go
@@ -163,6 +163,7 @@ type OpenOptions struct {
 type Port interface {
 	io.ReadWriteCloser
 	Fd() uintptr
+	Flush(in, out bool) error
 }
 
 // Open creates a Port based on the supplied options struct.


### PR DESCRIPTION
This allows using Silicon Labs' CP210x runtime library while having the serial port open and in use. That can be used for e.g. controlling the GPIO on Windows.